### PR TITLE
Set version to 0.1.0b1 — first public beta release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 
 **TheNightOps** — Autonomous SRE Agent for Kubernetes, built on Google ADK and Gemini.
-- **Version:** 0.3.0
+- **Version:** 0.1.0b1
 - **License:** Apache 2.0
 - **Python:** 3.11+
 - **Package manager:** pip with hatchling build backend

--- a/docs/assets/script.js
+++ b/docs/assets/script.js
@@ -101,7 +101,7 @@
 
     var lines = [
       { type: 'output', text: '' },
-      { type: 'info', text: '🌙 TheNightOps v0.3.0 — Autonomous SRE Agent' },
+      { type: 'info', text: '🌙 TheNightOps v0.1.0b1 — Autonomous SRE Agent' },
       { type: 'output', text: '' },
       { type: 'output', text: '[Phase 1/4] Triage — checking pod status...' },
       { type: 'success', text: '  Found: pod/api-server-7d4f9 OOMKilled (exit 137)' },

--- a/docs/index.html
+++ b/docs/index.html
@@ -70,7 +70,7 @@
     <div class="container hero-content">
       <div class="hero-badge">
         <span class="badge-dot"></span>
-        v0.3.0 &mdash; Built with Google ADK
+        v0.1.0b1 &mdash; Built with Google ADK
         <span class="badge-beta">BETA</span>
       </div>
       <h1 class="hero-title">
@@ -642,17 +642,9 @@
         <div class="timeline-item" data-aos>
           <div class="timeline-marker"></div>
           <div class="timeline-content">
-            <span class="timeline-date">v0.2.0 &mdash; Initial Release</span>
-            <h3>Foundation</h3>
-            <p>Multi-agent architecture with custom MCP servers. Webhook receiver, policy engine, and CLI. 5 demo failure scenarios.</p>
-          </div>
-        </div>
-        <div class="timeline-item" data-aos>
-          <div class="timeline-marker"></div>
-          <div class="timeline-content">
-            <span class="timeline-date">v0.3.0 &mdash; Major Upgrade</span>
-            <h3>Dual-Mode Architecture</h3>
-            <p>Gemini 3.1 Pro upgrade. Official Google Cloud MCP support. Plan B Simple Mode for zero-setup demos. Real-time WebSocket dashboard.</p>
+            <span class="timeline-date">v0.1.0b1 &mdash; First Public Beta</span>
+            <h3>Foundation + Dual-Mode Architecture</h3>
+            <p>Multi-agent architecture with custom MCP servers. Gemini 3.1 Pro, official Google Cloud MCP support. Webhook receiver, policy engine, CLI, and real-time WebSocket dashboard. 5 demo failure scenarios.</p>
           </div>
         </div>
         <div class="timeline-item" data-aos>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thenightops"
-version = "0.3.0"
+version = "0.1.0b1"
 description = "Autonomous SRE Agent built on Google ADK and Remote MCP — with proactive detection, incident memory, and graduated remediation"
 readme = "README.md"
 license = "Apache-2.0 WITH Commons-Clause-1.0"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """TheNightOps - Autonomous SRE Agent built on Google ADK and Remote MCP."""
 
-__version__ = "0.2.0"
+__version__ = "0.1.0b1"


### PR DESCRIPTION
Unified all version references across pyproject.toml, src/__init__.py, CLAUDE.md, static website, and terminal animation. Consolidated the v0.2.0/v0.3.0 timeline into a single v0.1.0b1 entry.